### PR TITLE
Feat/Refact: 비상 연락처 API 추가, 유효성 검증 오류 처리 메서드 추가

### DIFF
--- a/src/main/java/com/untitled/cherrymap/controller/MemberController.java
+++ b/src/main/java/com/untitled/cherrymap/controller/MemberController.java
@@ -1,26 +1,48 @@
 package com.untitled.cherrymap.controller;
 
 import com.untitled.cherrymap.domain.Member;
+import com.untitled.cherrymap.dto.PhoneNumberRequest;
 import com.untitled.cherrymap.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @Tag(name="Member-Controller",description = "유저 정보 조회 API")
+@RequestMapping("/api/{providerId}")
 public class MemberController {
 
     private final MemberService memberService;
 
     @Operation(summary = "사용자 정보 요청", description = "providerId에 해당하는 유저 정보를 json 형태로 반환.")
-    @GetMapping("/api/{providerId}/info")
+    @GetMapping("/info")
     public ResponseEntity<Member> getMember(@PathVariable String providerId) {
         Member member = memberService.getMemberByProviderId(providerId);
         return ResponseEntity.ok().body(member);
+    }
+
+    @Operation(summary = "비상연락처 조회", description = "사용자의 비상연락처를 조회합니다.")
+    @GetMapping("/phone")
+    public ResponseEntity<String> getPhoneNumber(@PathVariable String providerId) {
+        String phoneNumber = memberService.getPhoneNumber(providerId);
+        return ResponseEntity.ok(phoneNumber);
+    }
+
+    @Operation(summary = "비상연락처 등록 및 변경", description = "비상연락처를 등록 및 변경합니다.")
+    @PutMapping("/phone")
+    public ResponseEntity<Void> updatePhoneNumber(@PathVariable String providerId, @RequestBody @Valid PhoneNumberRequest request) {
+        memberService.updatePhoneNumber(providerId, request.getPhoneNumber());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "비상연락처 삭제", description = "비상연락처를 삭제합니다.")
+    @DeleteMapping("/phone")
+    public ResponseEntity<Void> deletePhoneNumber(@PathVariable String providerId) {
+        memberService.deletePhoneNumber(providerId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/untitled/cherrymap/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/untitled/cherrymap/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.untitled.cherrymap.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.time.LocalDateTime;
@@ -18,6 +20,26 @@ public class GlobalExceptionHandler {
         errorBody.put("status", HttpStatus.BAD_REQUEST.value());
         errorBody.put("error", "Bad Request");
         errorBody.put("message", ex.getMessage());
+
+        return ResponseEntity.badRequest().body(errorBody);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationException(MethodArgumentNotValidException ex) {
+        Map<String, Object> errorBody = new HashMap<>();
+        errorBody.put("timestamp", LocalDateTime.now());
+        errorBody.put("status", HttpStatus.BAD_REQUEST.value());
+        errorBody.put("error", "Validation Failed");
+
+        // 첫 번째 오류만 추출
+        FieldError fieldError = ex.getBindingResult().getFieldError();
+        if (fieldError != null) {
+            errorBody.put("message", fieldError.getDefaultMessage());
+            errorBody.put("field", fieldError.getField());
+            errorBody.put("rejectedValue", fieldError.getRejectedValue());
+        } else {
+            errorBody.put("message", "요청 데이터의 유효성 검사에 실패했습니다.");
+        }
 
         return ResponseEntity.badRequest().body(errorBody);
     }

--- a/src/main/java/com/untitled/cherrymap/service/MemberService.java
+++ b/src/main/java/com/untitled/cherrymap/service/MemberService.java
@@ -22,4 +22,32 @@ public class MemberService {
         }
         return member;
     }
+
+    @Transactional(readOnly = true)
+    public String getPhoneNumber(String providerId) {
+        Member member = memberRepository.findByProviderId(providerId);
+        if (member == null) {
+            throw new BadRequestException(ErrorMessage.MEMBER_NOT_FOUND_WITH + providerId);
+        }
+        return member.getPhoneNumber(); // null일 수도 있음
+    }
+
+    @Transactional
+    public void updatePhoneNumber(String providerId, String phoneNumber) {
+        Member member = memberRepository.findByProviderId(providerId);
+        if (member == null) {
+            throw new BadRequestException(ErrorMessage.MEMBER_NOT_FOUND_WITH + providerId);
+        }
+        member.setPhoneNumber(phoneNumber);
+    }
+
+    @Transactional
+    public void deletePhoneNumber(String providerId) {
+        Member member = memberRepository.findByProviderId(providerId);
+        if (member == null) {
+            throw new BadRequestException(ErrorMessage.MEMBER_NOT_FOUND_WITH + providerId);
+        }
+        member.setPhoneNumber(null);
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #40 비상 연락처 API 구현

## 📝작업 내용

> 1. 비상 연락처 API (GET, PUT, DELETE) 구현 완료
<img width="1083" alt="image" src="https://github.com/user-attachments/assets/5e5f63bb-1ad5-48b3-9e92-a471edb10f34" />

> 2. 유효성 검증 오류 처리 목적의 GlobalExceptionHandler 메서드 추가
## 스크린샷

### 1. 비상 연락처 조회
![스크린샷 2025-05-02 오전 3 09 28](https://github.com/user-attachments/assets/1fbf89b8-3c7e-4569-9659-7102f6712395)

### 2. 비상 연락처 수정 및 변경
(1) 성공
![스크린샷 2025-05-02 오전 3 09 41](https://github.com/user-attachments/assets/636d5694-2422-4573-88c1-c9e15f170c80)
(2) 잘못된 양식의 연락처
![스크린샷 2025-05-02 오전 3 14 50](https://github.com/user-attachments/assets/931f617b-43b4-470c-a78a-aa6fda56763c)

### 3. 비상 연락처 삭제
![스크린샷 2025-05-02 오전 3 15 00](https://github.com/user-attachments/assets/59152302-fcaa-450e-ac30-00f34a6ccaf2)

## 💬리뷰 요구사항

> 없음.
