### PR TITLE
refactor: Refresh 엔티티 구조 변경 및 memberId 기반 인증 흐름 적용

### DIFF
--- a/src/main/java/com/untitled/cherrymap/security/jwt/filter/JWTFilter.java
+++ b/src/main/java/com/untitled/cherrymap/security/jwt/filter/JWTFilter.java
@@ -3,6 +3,7 @@ package com.untitled.cherrymap.security.jwt.filter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.untitled.cherrymap.common.dto.ErrorResponse;
 import com.untitled.cherrymap.domain.member.domain.Member;
+import com.untitled.cherrymap.domain.member.exception.MemberNotFoundException;
 import com.untitled.cherrymap.security.dto.CustomUserDetailsDTO;
 import com.untitled.cherrymap.domain.member.dao.MemberRepository;
 import com.untitled.cherrymap.security.jwt.util.JWTUtil;
@@ -30,22 +31,20 @@ import java.io.PrintWriter;
 public class JWTFilter extends OncePerRequestFilter {
 
     private final JWTUtil jwtUtil;
-    private final MemberRepository memberRepository;      // DB에서 사용자 정보 조회용
+    private final MemberRepository memberRepository;
     private final ObjectMapper objectMapper;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
 
-        // 요청 헤더에서 Access 토큰 가져오기
         String accessToken = request.getHeader("access");
 
-        // 토큰 없으면 다음 필터로 넘어가기
         if (accessToken == null) {
             filterChain.doFilter(request, response);
-            return; // 필수 종료
+            return;
         }
 
-        // 토큰 만료 여부 확인 (만료시 다음 필터로 넘기지 않음, 401 응답 반환)
         try {
             jwtUtil.isExpired(accessToken);
         } catch (ExpiredJwtException e) {
@@ -57,38 +56,28 @@ public class JWTFilter extends OncePerRequestFilter {
             return;
         }
 
-
-        // 해당 토큰이 Access 토큰인지 확인
         String category = jwtUtil.getCategory(accessToken);
-
         if (!category.equals("access")) {
-            PrintWriter writer = response.getWriter();
-            writer.print("invalid access token");
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().print("invalid access token");
             return;
         }
 
-        // 유효한 토큰일 경우 사용자 정보 추출
-        String nickname = jwtUtil.getNickname(accessToken);
+        // memberId 기반으로 사용자 조회
+        String memberId = jwtUtil.getMemberId(accessToken);
 
-        // DB에서 사용자 정보 조회 (실제 존재하는지 검증)
-       Member member = memberRepository.findByNickname(nickname);
-        if (member == null) {
-            throw new UsernameNotFoundException("User not found");
-        }
+        Member member = memberRepository.findById(Long.parseLong(memberId))
+                .orElseThrow(() -> MemberNotFoundException.EXCEPTION);
 
-        // User 정보 기반으로 UserDetails 생성
         CustomUserDetailsDTO customUserDetailsDTO = new CustomUserDetailsDTO(member);
 
-        // Authentication 객체 생성
-        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetailsDTO, null, customUserDetailsDTO.getAuthorities()
+        Authentication authToken = new UsernamePasswordAuthenticationToken(
+                customUserDetailsDTO,
+                null,
+                customUserDetailsDTO.getAuthorities()
         );
 
-        // 인증 객체를 SecurityContextHolder에 저장 -> 이후 인증 완료 상태로 요청 처리됨
         SecurityContextHolder.getContext().setAuthentication(authToken);
-
-        // 다음 필터로 요청 전달
         filterChain.doFilter(request, response);
     }
 }
-

--- a/src/main/java/com/untitled/cherrymap/security/jwt/refresh/Refresh.java
+++ b/src/main/java/com/untitled/cherrymap/security/jwt/refresh/Refresh.java
@@ -1,14 +1,10 @@
 package com.untitled.cherrymap.security.jwt.refresh;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.untitled.cherrymap.domain.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -20,7 +16,14 @@ public class Refresh {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String nickname;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(unique = true, nullable = false, length = 350)
     private String refresh;
-    private String expiration;
+
+    @Column(nullable = false)
+    private LocalDateTime expiration;
 }

--- a/src/main/java/com/untitled/cherrymap/security/jwt/refresh/RefreshRepository.java
+++ b/src/main/java/com/untitled/cherrymap/security/jwt/refresh/RefreshRepository.java
@@ -3,9 +3,12 @@ package com.untitled.cherrymap.security.jwt.refresh;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 public interface RefreshRepository extends JpaRepository<Refresh, Long> {
 
     Boolean existsByRefresh(String refresh);
+    Optional<Refresh> findByRefresh(String refresh);
 
     @Transactional
     void deleteByRefresh(String refresh);

--- a/src/main/java/com/untitled/cherrymap/security/jwt/refresh/ReissueService.java
+++ b/src/main/java/com/untitled/cherrymap/security/jwt/refresh/ReissueService.java
@@ -1,6 +1,8 @@
 package com.untitled.cherrymap.security.jwt.refresh;
 
 import com.untitled.cherrymap.common.dto.SuccessResponse;
+import com.untitled.cherrymap.domain.member.dao.MemberRepository;
+import com.untitled.cherrymap.domain.member.domain.Member;
 import com.untitled.cherrymap.security.exception.refreshException.ExpiredRefreshTokenException;
 import com.untitled.cherrymap.security.exception.refreshException.InvalidRefreshTokenException;
 import com.untitled.cherrymap.security.jwt.JwtProperties;
@@ -12,6 +14,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.Map;
 
@@ -24,10 +27,11 @@ public class ReissueService {
     private final JWTUtil jwtUtil;
     private final RefreshRepository refreshRepository;
     private final JwtProperties jwtProperties;
+    private final MemberRepository memberRepository;
 
     public SuccessResponse<?> reissue(HttpServletRequest request, HttpServletResponse response) {
 
-        // 쿠키에서 Refresh 토큰 추출
+        // 1. 쿠키에서 Refresh Token 추출
         String refresh = null;
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
@@ -43,32 +47,36 @@ public class ReissueService {
             throw InvalidRefreshTokenException.EXCEPTION;
         }
 
+        // 2. 토큰 만료 여부 확인
         try {
             jwtUtil.isExpired(refresh);
         } catch (ExpiredJwtException e) {
             throw ExpiredRefreshTokenException.EXCEPTION;
         }
 
+        // 3. 카테고리 확인
         if (!"refresh".equals(jwtUtil.getCategory(refresh))) {
             throw InvalidRefreshTokenException.EXCEPTION;
         }
 
-        if (!refreshRepository.existsByRefresh(refresh)) {
-            throw InvalidRefreshTokenException.EXCEPTION;
-        }
+        // 4. 저장된 refresh token인지 확인
+        Refresh stored = refreshRepository.findByRefresh(refresh)
+                .orElseThrow(() -> InvalidRefreshTokenException.EXCEPTION);
 
-        String nickname = jwtUtil.getNickname(refresh);
-        String role = jwtUtil.getRole(refresh);
+        Member member = stored.getMember();
 
+        // 5. 새 토큰 생성
         Long accessExp = jwtProperties.getAccessTokenExpirationMs();
         Long refreshExp = jwtProperties.getRefreshTokenExpirationMs();
 
-        String newAccess = jwtUtil.createJwt("access", nickname, role, accessExp);
-        String newRefresh = jwtUtil.createJwt("refresh", nickname, role, refreshExp);
+        String newAccess = jwtUtil.createJwt("access", member.getId().toString(), member.getRole(), accessExp);
+        String newRefresh = jwtUtil.createJwt("refresh", member.getId().toString(), member.getRole(), refreshExp);
 
+        // 6. 기존 토큰 삭제 및 새 토큰 저장
         refreshRepository.deleteByRefresh(refresh);
-        addRefresh(nickname, newRefresh, refreshExp);
+        addRefresh(member, newRefresh, refreshExp);
 
+        // 7. 응답에 토큰 포함
         response.setHeader("access", newAccess);
         response.addCookie(createCookie("refresh", newRefresh));
 
@@ -77,20 +85,19 @@ public class ReissueService {
 
     private Cookie createCookie(String key, String value) {
         Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge((int)(jwtProperties.getRefreshTokenExpirationMs() / 1000)); // 초 단위로 변환
+        cookie.setMaxAge((int) (jwtProperties.getRefreshTokenExpirationMs() / 1000));
         cookie.setHttpOnly(true);
+        cookie.setPath("/");
         return cookie;
     }
 
-    private void addRefresh(String nickname, String refreshToken, Long expiredMs) {
-        Date date = new Date(System.currentTimeMillis() + expiredMs);
+    private void addRefresh(Member member, String refreshToken, Long expiredMs) {
         Refresh refresh = Refresh.builder()
-                .nickname(nickname)
+                .member(member)
                 .refresh(refreshToken)
-                .expiration(date.toString())
+                .expiration(LocalDateTime.now().plusSeconds(expiredMs / 1000))
                 .build();
 
         refreshRepository.save(refresh);
     }
 }
-

--- a/src/main/java/com/untitled/cherrymap/security/jwt/util/JWTUtil.java
+++ b/src/main/java/com/untitled/cherrymap/security/jwt/util/JWTUtil.java
@@ -9,43 +9,62 @@ import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
-// JWT 생성, 파싱/검증
 @Component
 public class JWTUtil {
 
-    private SecretKey secretKey;
+    private final SecretKey secretKey;
 
-    // application.yml의 시크릿 기반으로 SecretKey 생성
     public JWTUtil(@Value("${spring.jwt.secret}") String secret) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
-    // 검증
-    public String getNickname(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("nickname",String.class);
-    }
-    public String getRole(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role",String.class);
-    }
-    public String getCategory(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category",String.class);
-    }
-    public Boolean isExpired(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    // 사용자 ID 반환 (기존 nickname -> memberId)
+    public String getMemberId(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("memberId", String.class); // ID는 일반적으로 String 또는 Long
     }
 
-    // 토큰 생성
-    public String createJwt(String category, String nickname, String role, Long expiredMs) {
+    public String getRole(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("role", String.class);
+    }
+
+    public String getCategory(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("category", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getExpiration()
+                .before(new Date());
+    }
+
+    // 토큰 생성 시 memberId 기반으로 변경
+    public String createJwt(String category, String memberId, String role, Long expiredMs) {
         return Jwts.builder()
                 .claim("category", category)
-                .claim("nickname",nickname)
-                .claim("role",role)
-                .issuedAt(new Date(System.currentTimeMillis()))
+                .claim("memberId", memberId)
+                .claim("role", role)
+                .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))
                 .signWith(secretKey)
                 .compact();
     }
-
-
 }
-

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -5,4 +5,4 @@ spring.datasource.password=1234
 # 개발 환경에서 ddl-auto 설정
 spring.jpa.hibernate.ddl-auto=update
 
-server.port=8086
+# server.port=8086


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

- Refresh 엔티티에서 nickname 제거, Member 연관관계 설정
- JWTUtil: nickname → memberId 기반 클레임 구조 변경
- JWTFilter / LoginFilter / ReissueService 등 전체 적용
- 인증 시 DB에서 memberId 기준으로 사용자 조회
- 토큰 payload 구조: memberId, role, category


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
