### PR TITLE
chore: swagger의 jwt security 설정 추가

### DIFF
--- a/src/main/java/com/untitled/cherrymap/common/config/OpenApiConfig.java
+++ b/src/main/java/com/untitled/cherrymap/common/config/OpenApiConfig.java
@@ -3,22 +3,35 @@ package com.untitled.cherrymap.common.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/**
- * Swagger springdoc-ui 구성 파일
- */
 @Configuration
 public class OpenApiConfig {
+
     @Bean
     public OpenAPI openAPI() {
         Info info = new Info()
                 .title("cherrymap 프로젝트 API Document")
                 .version("v0.0.1")
                 .description("cherrymap 프로젝트의 API 명세서입니다.");
+
+        // JWT Security 설정
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("Authorization");
+
         return new OpenAPI()
-                .components(new Components())
-                .info(info);
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(new Components().addSecuritySchemes("Authorization", securityScheme));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> access token 넣고 테스트할 수 있도록 swagger 설정 추가
<img width="200" alt="image" src="https://github.com/user-attachments/assets/ab5720c4-dc58-4929-ad96-9736b9934903" />
<img width="100" height="528" alt="image" src="https://github.com/user-attachments/assets/f6687bb1-9ee1-4f84-9485-f73f4ca470b4" />



### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
