### PR TITLE
chore: swagger-ui 사용 시 dev/prod server dropdown 분리

### DIFF
--- a/src/main/java/com/untitled/cherrymap/common/config/OpenApiConfig.java
+++ b/src/main/java/com/untitled/cherrymap/common/config/OpenApiConfig.java
@@ -5,8 +5,11 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class OpenApiConfig {
@@ -31,6 +34,10 @@ public class OpenApiConfig {
 
         return new OpenAPI()
                 .info(info)
+                .servers(List.of(
+                        new Server().url("http://localhost:8080").description("Local Development"),
+                        new Server().url("https://cherrymap.click").description("Production Server")
+                ))
                 .addSecurityItem(securityRequirement)
                 .components(new Components().addSecuritySchemes("Authorization", securityScheme));
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #14 

## 📝작업 내용

> https 프로토콜 + 도메인 업데이트에 따른 swagger-ui 사용 시 dev/prod server dropdown 분리

### 스크린샷 (선택)
수정 되기 전 스샷입니다. 위치 참고용.
<img width="2056" height="878" alt="image" src="https://github.com/user-attachments/assets/bca7da76-f299-406e-81e9-71e453024d10" />

<img width="826" height="204" alt="image" src="https://github.com/user-attachments/assets/c62b44ca-5c57-46a2-a4a6-38f3e3461c21" />

