### PR TITLE
fix: Add CORS configuration for cherrymap.click domain

### DIFF
--- a/src/main/java/com/untitled/cherrymap/common/config/SecurityConfig.java
+++ b/src/main/java/com/untitled/cherrymap/common/config/SecurityConfig.java
@@ -92,7 +92,8 @@ public class SecurityConfig {
         config.setAllowedOrigins(List.of(
                 "http://localhost:5173",
                 "http://localhost:3000",
-                "https://cherrymap.pages.dev"
+                "https://cherrymap.pages.dev",
+                "https://cherrymap.click"
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
## #️⃣연관된 이슈

> #14 #83 

## 📝작업 내용

- CORS 설정 개선: https://cherrymap.click 도메인을 허용된 origin에 추가
- Swagger UI 서버 설정: 로컬 및 프로덕션 환경을 위한 서버 URL 설정 추가
- Swagger UI에서 프로덕션 서버(https://cherrymap.click)로 API 요청 시 발생하던 "Invalid CORS request" 오류 해결
- 토큰 발급 엔드포인트(/dev/token) 접근 시 403 Forbidden 오류 해결
