### PR TITLE
feat: 감정 기록 기능 구현 

### DIFF
--- a/src/main/java/com/untitled/cherrymap/common/config/SecurityConfig.java
+++ b/src/main/java/com/untitled/cherrymap/common/config/SecurityConfig.java
@@ -65,7 +65,7 @@ public class SecurityConfig {
                 // 경로별 인가 설정
                 .authorizeHttpRequests(auth -> auth
                         // 누구나 접근 가능한 공개 경로
-                        .requestMatchers("/", "/index.html", "/api/login", "/api/join","/api/check-nickname", "/api/reissue","/api/logout").permitAll()
+                        .requestMatchers("/", "/index.html", "/api/login", "/api/join","/api/check-nickname", "/api/reissue","/api/logout", "/api/emotions").permitAll()
                         // Swagger UI 관련 경로 허용
                         .requestMatchers("/cherrymap-ui.html", "/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**").permitAll()
                         // 정적 리소스 허용

--- a/src/main/java/com/untitled/cherrymap/domain/emotion/api/EmotionController.java
+++ b/src/main/java/com/untitled/cherrymap/domain/emotion/api/EmotionController.java
@@ -1,0 +1,39 @@
+package com.untitled.cherrymap.domain.emotion.api;
+
+import com.untitled.cherrymap.domain.emotion.application.EmotionService;
+import com.untitled.cherrymap.domain.emotion.dto.EmotionRequest;
+import com.untitled.cherrymap.domain.emotion.dto.EmotionResponse;
+import com.untitled.cherrymap.security.dto.CustomUserDetailsDTO;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/emotions")
+@RequiredArgsConstructor
+public class EmotionController {
+
+    private final EmotionService emotionService;
+
+    @PostMapping
+    public ResponseEntity<EmotionResponse> saveEmotion(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetailsDTO user,
+            @RequestBody EmotionRequest request
+    ) {
+        return ResponseEntity.ok(
+                emotionService.saveOrUpdateEmotion(request, user.getMember().getId())
+        );
+    }
+
+    @GetMapping
+    public ResponseEntity<EmotionResponse> getEmotionForRoute(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetailsDTO user,
+            @RequestParam Long routeId
+    ) {
+        return ResponseEntity.ok(
+                emotionService.getEmotionByRoute(user.getMember().getId(), routeId)
+        );
+    }
+}

--- a/src/main/java/com/untitled/cherrymap/domain/emotion/application/EmotionService.java
+++ b/src/main/java/com/untitled/cherrymap/domain/emotion/application/EmotionService.java
@@ -1,0 +1,47 @@
+package com.untitled.cherrymap.domain.emotion.application;
+
+import com.untitled.cherrymap.domain.emotion.dao.EmotionRepository;
+import com.untitled.cherrymap.domain.emotion.domain.Emotion;
+import com.untitled.cherrymap.domain.emotion.dto.EmotionRequest;
+import com.untitled.cherrymap.domain.emotion.dto.EmotionResponse;
+import com.untitled.cherrymap.domain.emotion.exception.EmotionNotFoundException;
+import com.untitled.cherrymap.domain.member.dao.MemberRepository;
+import com.untitled.cherrymap.domain.member.domain.Member;
+import com.untitled.cherrymap.domain.member.exception.MemberNotFoundException;
+import com.untitled.cherrymap.domain.route.dao.RouteRepository;
+import com.untitled.cherrymap.domain.route.domain.Route;
+import com.untitled.cherrymap.domain.route.exception.RouteNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmotionService {
+
+    private final EmotionRepository emotionRepository;
+    private final MemberRepository memberRepository;
+    private final RouteRepository routeRepository;
+
+    public EmotionResponse saveOrUpdateEmotion(EmotionRequest request, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> MemberNotFoundException.EXCEPTION);
+
+        Route route = routeRepository.findById(request.routeId())
+                .orElseThrow(() -> RouteNotFoundException.EXCEPTION);
+
+        Emotion emotion = emotionRepository.findByMemberIdAndRouteId(memberId, request.routeId())
+                .map(e -> {
+                    e.updateEmotion(request.emotion());
+                    return e;
+                })
+                .orElseGet(() -> new Emotion(member, route, request.emotion()));
+
+        return EmotionResponse.from(emotionRepository.save(emotion));
+    }
+
+    public EmotionResponse getEmotionByRoute(Long memberId, Long routeId) {
+        Emotion emotion = emotionRepository.findByMemberIdAndRouteId(memberId, routeId)
+                .orElseThrow(() -> EmotionNotFoundException.EXCEPTION);
+        return EmotionResponse.from(emotion);
+    }
+}

--- a/src/main/java/com/untitled/cherrymap/domain/emotion/dao/EmotionRepository.java
+++ b/src/main/java/com/untitled/cherrymap/domain/emotion/dao/EmotionRepository.java
@@ -1,0 +1,10 @@
+package com.untitled.cherrymap.domain.emotion.dao;
+
+import com.untitled.cherrymap.domain.emotion.domain.Emotion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmotionRepository extends JpaRepository<Emotion, Long> {
+    Optional<Emotion> findByMemberIdAndRouteId(Long memberId, Long routeId);
+}

--- a/src/main/java/com/untitled/cherrymap/domain/emotion/domain/Emotion.java
+++ b/src/main/java/com/untitled/cherrymap/domain/emotion/domain/Emotion.java
@@ -1,0 +1,51 @@
+package com.untitled.cherrymap.domain.emotion.domain;
+
+import com.untitled.cherrymap.domain.member.domain.Member;
+import com.untitled.cherrymap.domain.route.domain.Route;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "emotion", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "route_id"})
+})
+public class Emotion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "emotion_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "route_id", nullable = false)
+    private Route route;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EmotionType emotion;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    public Emotion(Member member, Route route, EmotionType emotion) {
+        this.member = member;
+        this.route = route;
+        this.emotion = emotion;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void updateEmotion(EmotionType newEmotion) {
+        this.emotion = newEmotion;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/untitled/cherrymap/domain/emotion/domain/EmotionType.java
+++ b/src/main/java/com/untitled/cherrymap/domain/emotion/domain/EmotionType.java
@@ -1,0 +1,5 @@
+package com.untitled.cherrymap.domain.emotion.domain;
+
+public enum EmotionType {
+    LIKE, ANGRY, SAD, SURPRISED, TIRED
+}

--- a/src/main/java/com/untitled/cherrymap/domain/emotion/dto/EmotionRequest.java
+++ b/src/main/java/com/untitled/cherrymap/domain/emotion/dto/EmotionRequest.java
@@ -1,0 +1,8 @@
+package com.untitled.cherrymap.domain.emotion.dto;
+
+import com.untitled.cherrymap.domain.emotion.domain.EmotionType;
+
+public record EmotionRequest(
+        Long routeId,
+        EmotionType emotion
+) {}

--- a/src/main/java/com/untitled/cherrymap/domain/emotion/dto/EmotionResponse.java
+++ b/src/main/java/com/untitled/cherrymap/domain/emotion/dto/EmotionResponse.java
@@ -1,0 +1,22 @@
+package com.untitled.cherrymap.domain.emotion.dto;
+
+import com.untitled.cherrymap.domain.emotion.domain.Emotion;
+import com.untitled.cherrymap.domain.emotion.domain.EmotionType;
+
+import java.time.LocalDateTime;
+
+public record EmotionResponse(
+        Long id,
+        Long routeId,
+        EmotionType emotion,
+        LocalDateTime createdAt
+) {
+    public static EmotionResponse from(Emotion e) {
+        return new EmotionResponse(
+                e.getId(),
+                e.getRoute().getId(),
+                e.getEmotion(),
+                e.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/untitled/cherrymap/domain/emotion/exception/EmotionErrorCode.java
+++ b/src/main/java/com/untitled/cherrymap/domain/emotion/exception/EmotionErrorCode.java
@@ -1,4 +1,4 @@
-package com.untitled.cherrymap.domain.route.exception;
+package com.untitled.cherrymap.domain.emotion.exception;
 
 import com.untitled.cherrymap.common.dto.ErrorReason;
 import com.untitled.cherrymap.common.exception.BaseErrorCode;
@@ -9,9 +9,9 @@ import static com.untitled.cherrymap.common.consts.CherrymapStatic.*;
 
 @Getter
 @AllArgsConstructor
-public enum RouteErrorCode implements BaseErrorCode {
-    ROUTE_ERROR_CODE(NOT_FOUND, "Route_404", "해당 경로를 찾을 수 없습니다."),
-    DUPLICATE_ROUTE(CONFLICT, "Route_409", "이미 존재하는 경로입니다.");
+public enum EmotionErrorCode implements BaseErrorCode {
+
+    EMOTION_ERROR_CODE(NOT_FOUND, "Emotion_404", "해당 감정 기록을 찾을 수 없습니다.");
 
     private final Integer status;
     private final String code;

--- a/src/main/java/com/untitled/cherrymap/domain/emotion/exception/EmotionNotFoundException.java
+++ b/src/main/java/com/untitled/cherrymap/domain/emotion/exception/EmotionNotFoundException.java
@@ -1,0 +1,11 @@
+package com.untitled.cherrymap.domain.emotion.exception;
+
+import com.untitled.cherrymap.common.exception.CherrymapCodeException;
+
+public class EmotionNotFoundException extends CherrymapCodeException {
+    public static final CherrymapCodeException EXCEPTION = new EmotionNotFoundException();
+
+    private EmotionNotFoundException() {
+        super(MemberErrorCode.MEMBER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/untitled/cherrymap/domain/emotion/exception/EmotionNotFoundException.java
+++ b/src/main/java/com/untitled/cherrymap/domain/emotion/exception/EmotionNotFoundException.java
@@ -6,6 +6,6 @@ public class EmotionNotFoundException extends CherrymapCodeException {
     public static final CherrymapCodeException EXCEPTION = new EmotionNotFoundException();
 
     private EmotionNotFoundException() {
-        super(MemberErrorCode.MEMBER_NOT_FOUND);
+        super(EmotionErrorCode.EMOTION_ERROR_CODE);
     }
 }

--- a/src/main/java/com/untitled/cherrymap/domain/route/domain/Route.java
+++ b/src/main/java/com/untitled/cherrymap/domain/route/domain/Route.java
@@ -4,7 +4,6 @@ import com.untitled.cherrymap.domain.member.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
-import com.untitled.cherrymap.domain.route.domain.RouteMode;
 import java.time.LocalDateTime;
 
 @Entity

--- a/src/main/java/com/untitled/cherrymap/domain/route/exception/RouteNotFoundException.java
+++ b/src/main/java/com/untitled/cherrymap/domain/route/exception/RouteNotFoundException.java
@@ -1,0 +1,11 @@
+package com.untitled.cherrymap.domain.route.exception;
+
+import com.untitled.cherrymap.common.exception.CherrymapCodeException;
+
+public class RouteNotFoundException extends CherrymapCodeException {
+    public static final CherrymapCodeException EXCEPTION = new RouteNotFoundException();
+
+    private RouteNotFoundException() {
+        super(RouteErrorCode.ROUTE_ERROR_CODE);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
close #91 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 감정 저장 API
`POST /api/emotions`
특정 경로에 감정 하나를 저장(기존에 저장된 감정이 있을 경우 덮어버림)
<img width="500" height="956" alt="image" src="https://github.com/user-attachments/assets/45e4d82d-7477-4002-845c-62fd2c778a4f" />


- 저장된 감정 조회 API
`GET /api/emotions?routeId={routeId}`
특정 경로의 감정 조회
<img width="500" height="836" alt="image" src="https://github.com/user-attachments/assets/0123ed88-d375-4922-bba4-968bd63354cd" />


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
