### PR TITLE
fix: Member 도메인 비상연락처 기능 개선 및 Route 도메인과 일관성 확보

### DIFF
--- a/src/main/java/com/untitled/cherrymap/domain/member/api/MemberController.java
+++ b/src/main/java/com/untitled/cherrymap/domain/member/api/MemberController.java
@@ -1,48 +1,71 @@
 package com.untitled.cherrymap.domain.member.api;
 
-import com.untitled.cherrymap.domain.member.domain.Member;
+import com.untitled.cherrymap.common.dto.SuccessResponse;
 import com.untitled.cherrymap.domain.member.application.MemberService;
+import com.untitled.cherrymap.domain.member.domain.Member;
+import com.untitled.cherrymap.domain.member.dto.MemberResponse;
 import com.untitled.cherrymap.domain.member.dto.PhoneNumberRequest;
+import com.untitled.cherrymap.domain.member.dto.PhoneNumberResponse;
+import com.untitled.cherrymap.security.dto.CustomUserDetailsDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name="Member-Controller",description = "유저 정보 조회 API")
-@RequestMapping("/api/{Id}")
+@Tag(name="Member-Controller",description = "사용자 정보 및 비상연락처 관리 API")
+@RequestMapping("/api/member")
 public class MemberController {
 
     private final MemberService memberService;
 
-    @Operation(summary = "사용자 정보 요청", description = "member_Id에 해당하는 유저 정보를 json 형태로 반환.")
+    @Operation(summary = "사용자 정보 요청", description = "로그인한 사용자의 정보를 json 형태로 반환.")
     @GetMapping("/info")
-    public ResponseEntity<Member> getMember(@PathVariable Long id) {
-        Member member = memberService.getMemberByMemberId(id);
-        return ResponseEntity.ok().body(member);
+    public ResponseEntity<SuccessResponse<MemberResponse>> getMember(
+            @AuthenticationPrincipal CustomUserDetailsDTO user) {
+        return ResponseEntity.ok(
+                SuccessResponse.success(200, MemberResponse.from(user.getMember()))
+        );
     }
 
-    @Operation(summary = "비상연락처 조회", description = "사용자의 비상연락처를 조회합니다.")
+    @Operation(summary = "비상연락처 조회", description = "로그인한 사용자의 비상연락처를 조회합니다.")
     @GetMapping("/phone")
-    public ResponseEntity<String> getPhoneNumber(@PathVariable Long id) {
-        String phoneNumber = memberService.getPhoneNumber(id);
-        return ResponseEntity.ok(phoneNumber);
+    public ResponseEntity<SuccessResponse<PhoneNumberResponse>> getPhoneNumber(
+            @AuthenticationPrincipal CustomUserDetailsDTO user) {
+        PhoneNumberResponse response = memberService.getPhoneNumber(user.getMember());
+        return ResponseEntity.ok(
+                SuccessResponse.success(200, response)
+        );
     }
 
-    @Operation(summary = "비상연락처 등록 및 변경", description = "비상연락처를 등록 및 변경합니다.")
+    @Operation(summary = "비상연락처 등록 및 변경", description = "비상연락처를 등록 및 변경합니다. xxx-xxxx-xxxx(휴대폰) 또는 xxx-xxx-xxxx(유선전화) 형식으로 입력해주세요.")
     @PutMapping("/phone")
-    public ResponseEntity<Void> updatePhoneNumber(@PathVariable Long id, @RequestBody @Valid PhoneNumberRequest request) {
-        memberService.updatePhoneNumber(id, request.getPhoneNumber());
-        return ResponseEntity.ok().build();
+    public ResponseEntity<SuccessResponse<Map<String, Object>>> updatePhoneNumber(
+            @AuthenticationPrincipal CustomUserDetailsDTO user,
+            @RequestBody @Valid PhoneNumberRequest request) {
+        memberService.updatePhoneNumber(user.getMember(), request.getPhoneNumber());
+        return ResponseEntity.ok(
+                SuccessResponse.success(200, Map.of(
+                        "message", "비상연락처가 성공적으로 등록/변경되었습니다."
+                ))
+        );
     }
 
     @Operation(summary = "비상연락처 삭제", description = "비상연락처를 삭제합니다.")
     @DeleteMapping("/phone")
-    public ResponseEntity<Void> deletePhoneNumber(@PathVariable Long id) {
-        memberService.deletePhoneNumber(id);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<SuccessResponse<Map<String, Object>>> deletePhoneNumber(
+            @AuthenticationPrincipal CustomUserDetailsDTO user) {
+        memberService.deletePhoneNumber(user.getMember());
+        return ResponseEntity.ok(
+                SuccessResponse.success(200, Map.of(
+                        "message", "비상연락처가 성공적으로 삭제되었습니다."
+                ))
+        );
     }
 }

--- a/src/main/java/com/untitled/cherrymap/domain/member/application/MemberService.java
+++ b/src/main/java/com/untitled/cherrymap/domain/member/application/MemberService.java
@@ -1,9 +1,10 @@
 package com.untitled.cherrymap.domain.member.application;
 
-import com.untitled.cherrymap.etc.exception.BadRequestException;
-import com.untitled.cherrymap.domain.member.domain.Member;
 import com.untitled.cherrymap.domain.member.dao.MemberRepository;
-import com.untitled.cherrymap.etc.message.ErrorMessage;
+import com.untitled.cherrymap.domain.member.domain.Member;
+import com.untitled.cherrymap.domain.member.dto.PhoneNumberResponse;
+import com.untitled.cherrymap.domain.member.exception.InvalidPhoneNumberException;
+import com.untitled.cherrymap.domain.member.exception.PhoneNumberNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,32 +15,63 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
-    @Transactional(readOnly = true)
-    public Member getMemberByMemberId(Long id) {
-        Member member = memberRepository.findById(id)
-                .orElseThrow(() -> new BadRequestException(ErrorMessage.MEMBER_NOT_FOUND_WITH + id));
-        return member;
-    }
+
 
     @Transactional(readOnly = true)
-    public String getPhoneNumber(Long id) {
-        Member member = memberRepository.findById(id)
-                .orElseThrow(() -> new BadRequestException(ErrorMessage.MEMBER_NOT_FOUND_WITH + id));
-        return member.getPhoneNumber(); // null일 수도 있음
+    public PhoneNumberResponse getPhoneNumber(Member member) {
+        if (member.getPhoneNumber() == null || member.getPhoneNumber().isBlank()) {
+            throw PhoneNumberNotFoundException.EXCEPTION;
+        }
+        
+        return toPhoneNumberResponse(member);
     }
 
     @Transactional
-    public void updatePhoneNumber(Long id, String phoneNumber) {
-        Member member = memberRepository.findById(id)
-                .orElseThrow(() -> new BadRequestException(ErrorMessage.MEMBER_NOT_FOUND_WITH + id));
+    public void updatePhoneNumber(Member member, String phoneNumber) {
+        // 전화번호 형식 검증
+        validatePhoneNumberFormat(phoneNumber);
+        
         member.setPhoneNumber(phoneNumber);
     }
 
     @Transactional
-    public void deletePhoneNumber(Long id) {
-        Member member = memberRepository.findById(id)
-                .orElseThrow(() -> new BadRequestException(ErrorMessage.MEMBER_NOT_FOUND_WITH + id));
+    public void deletePhoneNumber(Member member) {
+        if (member.getPhoneNumber() == null || member.getPhoneNumber().isBlank()) {
+            throw PhoneNumberNotFoundException.EXCEPTION;
+        }
+        
         member.setPhoneNumber(null);
     }
 
+    // 전화번호 형식 검증
+    private void validatePhoneNumberFormat(String phoneNumber) {
+        if (phoneNumber == null || phoneNumber.isBlank()) {
+            throw InvalidPhoneNumberException.EXCEPTION;
+        }
+        
+        // 휴대폰: xxx-xxxx-xxxx, 유선전화: xxx-xxx-xxxx 형식 검증
+        if (!phoneNumber.matches("^(\\d{3}-\\d{4}-\\d{4}|\\d{3}-\\d{3}-\\d{4})$")) {
+            throw InvalidPhoneNumberException.EXCEPTION;
+        }
+    }
+
+    // 전화번호 타입 판별
+    private String getPhoneType(String phoneNumber) {
+        if (phoneNumber.matches("^\\d{3}-\\d{4}-\\d{4}$")) {
+            return "휴대폰";
+        } else if (phoneNumber.matches("^\\d{3}-\\d{3}-\\d{4}$")) {
+            return "유선전화";
+        }
+        return "알 수 없음";
+    }
+
+    // PhoneNumberResponse DTO 변환
+    private PhoneNumberResponse toPhoneNumberResponse(Member member) {
+        return PhoneNumberResponse.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .phoneNumber(member.getPhoneNumber())
+                .phoneType(getPhoneType(member.getPhoneNumber()))
+                .build();
+    }
 }

--- a/src/main/java/com/untitled/cherrymap/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/untitled/cherrymap/domain/member/dto/MemberResponse.java
@@ -1,0 +1,38 @@
+package com.untitled.cherrymap.domain.member.dto;
+
+import com.untitled.cherrymap.domain.member.domain.Member;
+import com.untitled.cherrymap.domain.member.domain.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "사용자 정보 응답 DTO")
+public record MemberResponse(
+
+        @Schema(description = "사용자 ID", example = "1")
+        Long memberId,
+
+        @Schema(description = "유저 닉네임", example = "cherryUser")
+        String nickname,
+
+        @Schema(description = "유저 이름", example = "홍길동")
+        String username,
+
+        @Schema(description = "역할", example = "ROLE_USER", allowableValues = {"ROLE_USER", "ROLE_ADMIN", "ROLE_MODERATOR"})
+        UserRole role,
+
+        @Schema(description = "비상연락처", example = "010-1234-5678")
+        String phoneNumber
+) {
+    @Builder
+    public MemberResponse {}
+
+    public static MemberResponse from(Member member) {
+        return MemberResponse.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .username(member.getUsername())
+                .role(member.getRole())
+                .phoneNumber(member.getPhoneNumber())
+                .build();
+    }
+} 

--- a/src/main/java/com/untitled/cherrymap/domain/member/dto/PhoneNumberRequest.java
+++ b/src/main/java/com/untitled/cherrymap/domain/member/dto/PhoneNumberRequest.java
@@ -4,13 +4,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
-@Schema(description = "비상 연락처 추가/변경/수정 시 RequestBody DTO(JSON)")
+@Setter
+@Schema(description = "비상연락처 등록/변경 시 요청 DTO (RequestBody)")
 public class PhoneNumberRequest {
 
     @NotNull(message = "전화번호는 반드시 포함되어야 합니다.")
-    @Pattern(regexp = "^\\d{3}-\\d{4}-\\d{4}$", message = "비상연락처는 xxx-xxxx-xxxx 형식이어야 합니다.")
-    @Schema(description = "전화번호", example = "010-1234-5678")
+    @Pattern(regexp = "^(\\d{3}-\\d{4}-\\d{4}|\\d{3}-\\d{3}-\\d{4})$", 
+             message = "비상연락처는 xxx-xxxx-xxxx(휴대폰) 또는 xxx-xxx-xxxx(유선전화) 형식이어야 합니다.")
+    @Schema(description = "비상연락처", example = "010-1234-5678", 
+            allowableValues = {"휴대폰: xxx-xxxx-xxxx", "유선전화: xxx-xxx-xxxx"})
     private String phoneNumber;
 }

--- a/src/main/java/com/untitled/cherrymap/domain/member/dto/PhoneNumberResponse.java
+++ b/src/main/java/com/untitled/cherrymap/domain/member/dto/PhoneNumberResponse.java
@@ -1,0 +1,23 @@
+package com.untitled.cherrymap.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "비상연락처 응답 DTO")
+public record PhoneNumberResponse(
+
+        @Schema(description = "사용자 ID", example = "1")
+        Long memberId,
+
+        @Schema(description = "사용자 닉네임", example = "cherryUser")
+        String nickname,
+
+        @Schema(description = "비상연락처", example = "010-1234-5678")
+        String phoneNumber,
+
+        @Schema(description = "전화번호 타입", example = "휴대폰", allowableValues = {"휴대폰", "유선전화"})
+        String phoneType
+) {
+    @Builder
+    public PhoneNumberResponse {}
+} 

--- a/src/main/java/com/untitled/cherrymap/domain/member/exception/DuplicateNicknameException.java
+++ b/src/main/java/com/untitled/cherrymap/domain/member/exception/DuplicateNicknameException.java
@@ -3,7 +3,7 @@ package com.untitled.cherrymap.domain.member.exception;
 import com.untitled.cherrymap.common.exception.CherrymapCodeException;
 
 public class DuplicateNicknameException extends CherrymapCodeException {
-    public static final CherrymapCodeException EXCEPTION = new DuplicateNicknameException();
+    public static final DuplicateNicknameException EXCEPTION = new DuplicateNicknameException();
 
     private DuplicateNicknameException() {
         super(MemberErrorCode.DUPLICATE_NICKNAME);

--- a/src/main/java/com/untitled/cherrymap/domain/member/exception/InvalidPhoneNumberException.java
+++ b/src/main/java/com/untitled/cherrymap/domain/member/exception/InvalidPhoneNumberException.java
@@ -1,0 +1,11 @@
+package com.untitled.cherrymap.domain.member.exception;
+
+import com.untitled.cherrymap.common.exception.CherrymapCodeException;
+
+public class InvalidPhoneNumberException extends CherrymapCodeException {
+    public static final InvalidPhoneNumberException EXCEPTION = new InvalidPhoneNumberException();
+
+    private InvalidPhoneNumberException() {
+        super(MemberErrorCode.INVALID_PHONE_NUMBER_FORMAT);
+    }
+} 

--- a/src/main/java/com/untitled/cherrymap/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/untitled/cherrymap/domain/member/exception/MemberErrorCode.java
@@ -10,9 +10,10 @@ import static com.untitled.cherrymap.common.consts.CherrymapStatic.*;
 @Getter
 @AllArgsConstructor
 public enum MemberErrorCode implements BaseErrorCode {
-
     MEMBER_NOT_FOUND(NOT_FOUND, "Member_404", "해당 사용자를 찾을 수 없습니다."),
-    DUPLICATE_NICKNAME(CONFLICT, "Member_409", "이미 사용 중인 닉네임입니다.");
+    DUPLICATE_NICKNAME(CONFLICT, "Member_409", "이미 존재하는 닉네임입니다."),
+    INVALID_PHONE_NUMBER_FORMAT(BAD_REQUEST, "Member_400", "올바르지 않은 전화번호 형식입니다. xxx-xxxx-xxxx(휴대폰) 또는 xxx-xxx-xxxx(유선전화) 형식으로 입력해주세요."),
+    PHONE_NUMBER_NOT_FOUND(NOT_FOUND, "Member_404", "등록된 비상연락처가 없습니다.");
 
     private final Integer status;
     private final String code;

--- a/src/main/java/com/untitled/cherrymap/domain/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/untitled/cherrymap/domain/member/exception/MemberNotFoundException.java
@@ -3,7 +3,7 @@ package com.untitled.cherrymap.domain.member.exception;
 import com.untitled.cherrymap.common.exception.CherrymapCodeException;
 
 public class MemberNotFoundException extends CherrymapCodeException {
-    public static final CherrymapCodeException EXCEPTION = new MemberNotFoundException();
+    public static final MemberNotFoundException EXCEPTION = new MemberNotFoundException();
 
     private MemberNotFoundException() {
         super(MemberErrorCode.MEMBER_NOT_FOUND);

--- a/src/main/java/com/untitled/cherrymap/domain/member/exception/PhoneNumberNotFoundException.java
+++ b/src/main/java/com/untitled/cherrymap/domain/member/exception/PhoneNumberNotFoundException.java
@@ -1,0 +1,11 @@
+package com.untitled.cherrymap.domain.member.exception;
+
+import com.untitled.cherrymap.common.exception.CherrymapCodeException;
+
+public class PhoneNumberNotFoundException extends CherrymapCodeException {
+    public static final PhoneNumberNotFoundException EXCEPTION = new PhoneNumberNotFoundException();
+
+    private PhoneNumberNotFoundException() {
+        super(MemberErrorCode.PHONE_NUMBER_NOT_FOUND);
+    }
+} 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #40 #93 

## 📝작업 내용
### 주요 개선사항
- **API 엔드포인트 변경**: `/api/{Id}/phone` → `/api/member/phone` (인증 기반 접근)
- **보안 강화**: `@AuthenticationPrincipal` 사용으로 본인 정보만 접근 가능
- **전화번호 형식 검증**: 휴대폰(xxx-xxxx-xxxx) 및 유선전화(xxx-xxx-xxxx) 형식 지원
- **응답 구조 통일**: `SuccessResponse` 래퍼로 Route 도메인과 일관성 확보

### 아키텍처 개선
- **도메인별 예외 처리**: `InvalidPhoneNumberException`, `PhoneNumberNotFoundException` 추가
- **DTO 구조화**: `MemberResponse`, `PhoneNumberResponse` 추가
- **Swagger 문서화**: 상세한 API 명세 및 예시 제공

### Route 도메인과의 일관성 확보
- 동일한 인증 패턴 (`@AuthenticationPrincipal`)
- 동일한 응답 구조 (`SuccessResponse`)
- 동일한 예외 처리 패턴 (도메인별 예외 클래스)