### PR TITLE
feat: LLM 챗봇 API 중계 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/untitled/cherrymap/common/config/WebClientConfig.java
+++ b/src/main/java/com/untitled/cherrymap/common/config/WebClientConfig.java
@@ -1,0 +1,15 @@
+package com.untitled.cherrymap.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder()
+                .build();
+    }
+} 

--- a/src/main/java/com/untitled/cherrymap/domain/llm/api/LlmController.java
+++ b/src/main/java/com/untitled/cherrymap/domain/llm/api/LlmController.java
@@ -1,0 +1,48 @@
+package com.untitled.cherrymap.domain.llm.api;
+
+import com.untitled.cherrymap.domain.llm.application.LlmService;
+import com.untitled.cherrymap.domain.llm.dto.LlmChatRequest;
+import com.untitled.cherrymap.domain.llm.dto.LlmChatResponse;
+import com.untitled.cherrymap.security.dto.CustomUserDetailsDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Tag(name = "LLM Chat", description = "LLM 챗봇 API")
+public class LlmController {
+
+    private final LlmService llmService;
+
+    @PostMapping("/chat")
+    @Operation(
+        summary = "LLM 챗봇 대화",
+        description = "발달장애인을 위한 내비게이션 챗봇과 대화합니다. 길 이탈, 대중교통 놓침 등의 상황에 대한 도움을 제공합니다.",
+        responses = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "챗봇 응답 성공",
+                content = @io.swagger.v3.oas.annotations.media.Content(
+                    mediaType = "application/json",
+                    schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = LlmChatResponse.class)
+                )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "500",
+                description = "LLM 서버 통신 오류"
+            )
+        }
+    )
+    public ResponseEntity<LlmChatResponse> chat(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetailsDTO user,
+            @RequestBody LlmChatRequest request
+    ) {
+        return ResponseEntity.ok(llmService.processChatRequest(request));
+    }
+} 

--- a/src/main/java/com/untitled/cherrymap/domain/llm/application/LlmService.java
+++ b/src/main/java/com/untitled/cherrymap/domain/llm/application/LlmService.java
@@ -1,0 +1,47 @@
+package com.untitled.cherrymap.domain.llm.application;
+
+import com.untitled.cherrymap.domain.llm.dto.LlmChatRequest;
+import com.untitled.cherrymap.domain.llm.dto.LlmChatResponse;
+import com.untitled.cherrymap.domain.llm.exception.LlmCommunicationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LlmService {
+
+    private final WebClient webClient;
+    
+    @Value("${llm.server.url:http://ai.cherrymap.click}")
+    private String llmServerUrl;
+
+    public LlmChatResponse processChatRequest(LlmChatRequest request) {
+        log.info("LLM 챗봇 요청 처리 시작. 메시지: {}", request.message().substring(0, Math.min(50, request.message().length())));
+        
+        try {
+            return webClient.post()
+                    .uri(llmServerUrl + "/api/v1/chat")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(LlmChatResponse.class)
+                    .doOnSuccess(response -> log.info("LLM 챗봇 응답 수신. 액션: {}", response.actionType()))
+                    .doOnError(error -> log.error("LLM 서버 통신 오류: {}", error.getMessage()))
+                    .block();
+                    
+        } catch (WebClientResponseException e) {
+            log.error("LLM 서버 HTTP 오류: {} - {}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw LlmCommunicationException.EXCEPTION;
+        } catch (Exception e) {
+            log.error("LLM 서버 통신 중 예상치 못한 오류: {}", e.getMessage());
+            throw LlmCommunicationException.EXCEPTION;
+        }
+    }
+} 

--- a/src/main/java/com/untitled/cherrymap/domain/llm/dto/LlmChatRequest.java
+++ b/src/main/java/com/untitled/cherrymap/domain/llm/dto/LlmChatRequest.java
@@ -1,0 +1,41 @@
+package com.untitled.cherrymap.domain.llm.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "LLM 챗봇 요청")
+public record LlmChatRequest(
+        @Schema(description = "사용자의 질문이나 도움 요청 메시지", example = "길을 잃었어요")
+        @NotBlank(message = "메시지는 필수입니다")
+        @Size(max = 1000, message = "메시지는 1000자를 초과할 수 없습니다")
+        String message,
+        
+        @Schema(description = "사용자의 현재 위치 정보")
+        @NotNull(message = "위치 정보는 필수입니다")
+        LocationInfo location,
+        
+        @Schema(description = "목적지 주소 (선택사항)", example = "서울시 강남구 테헤란로 123")
+        @JsonProperty("destination_address")
+        String destinationAddress,
+        
+        @Schema(description = "이동 수단 (도보, 대중교통)", example = "대중교통")
+        String mode,
+        
+        @Schema(description = "사용자 상황 설명 (선택사항)", example = "지하철을 놓쳤어요")
+        @JsonProperty("user_context")
+        String userContext
+) {
+    @Schema(description = "위치 정보")
+    public record LocationInfo(
+            @Schema(description = "위도", example = "37.5665")
+            @NotNull(message = "위도는 필수입니다")
+            Double latitude,
+            
+            @Schema(description = "경도", example = "126.9780")
+            @NotNull(message = "경도는 필수입니다")
+            Double longitude
+    ) {}
+} 

--- a/src/main/java/com/untitled/cherrymap/domain/llm/dto/LlmChatResponse.java
+++ b/src/main/java/com/untitled/cherrymap/domain/llm/dto/LlmChatResponse.java
@@ -1,0 +1,21 @@
+package com.untitled.cherrymap.domain.llm.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "LLM 챗봇 응답")
+public record LlmChatResponse(
+        @Schema(description = "챗봇의 답변 메시지", example = "걱정하지 마세요! 현재 위치에서 가장 가까운 지하철역을 찾아드릴게요.")
+        String response,
+        
+        @Schema(description = "사용된 AI 모델명", example = "gemini-1.5-flash")
+        String model,
+        
+        @Schema(description = "제안하는 액션 타입", example = "find_nearby_station")
+        @JsonProperty("action_type")
+        String actionType,
+        
+        @Schema(description = "응답의 신뢰도 점수 (0.0 ~ 1.0)", example = "0.95")
+        @JsonProperty("confidence_score")
+        Double confidenceScore
+) {} 

--- a/src/main/java/com/untitled/cherrymap/domain/llm/exception/LlmCommunicationException.java
+++ b/src/main/java/com/untitled/cherrymap/domain/llm/exception/LlmCommunicationException.java
@@ -1,0 +1,12 @@
+package com.untitled.cherrymap.domain.llm.exception;
+
+import com.untitled.cherrymap.common.exception.BaseErrorCode;
+import com.untitled.cherrymap.common.exception.CherrymapCodeException;
+
+public class LlmCommunicationException extends CherrymapCodeException {
+    public static final LlmCommunicationException EXCEPTION = new LlmCommunicationException();
+    
+    private LlmCommunicationException() {
+        super(LlmErrorCode.LLM_COMMUNICATION_ERROR);
+    }
+} 

--- a/src/main/java/com/untitled/cherrymap/domain/llm/exception/LlmErrorCode.java
+++ b/src/main/java/com/untitled/cherrymap/domain/llm/exception/LlmErrorCode.java
@@ -1,0 +1,30 @@
+package com.untitled.cherrymap.domain.llm.exception;
+
+import com.untitled.cherrymap.common.dto.ErrorReason;
+import com.untitled.cherrymap.common.exception.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum LlmErrorCode implements BaseErrorCode {
+    LLM_COMMUNICATION_ERROR(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            "LLM_COMMUNICATION_ERROR",
+            "LLM 서버와의 통신 중 오류가 발생했습니다."
+    );
+
+    private final int status;
+    private final String code;
+    private final String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.builder()
+                .status(this.status)
+                .code(this.code)
+                .reason(this.reason)
+                .build();
+    }
+} 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,3 +33,5 @@ spring.jwt.secret=${JWT_SECRET}
 jwt.access-token-expiration-ms=600000
 jwt.refresh-token-expiration-ms=86400000
 
+# LLM 서버 설정
+llm.server.url=http://ai.cherrymap.click


### PR DESCRIPTION
## #️⃣연관된 이슈

> #100 (LLM 챗봇 API 중계 기능 구현)

## 📝작업 내용

> LLM 챗봇 API 중계 기능을 추가 & Cherry-ai LLM 서버와의 통신 중계 아키텍처를 구현

### 주요 변경사항

### 아키텍처 플로우
```
프론트엔드 → Cherrymap 백엔드 → Cherry-ai LLM 서버
프론트엔드 ← Cherrymap 백엔드 ← Cherry-ai LLM 서버
```

### API 사용 예시
```bash
POST /api/v1/chat
Content-Type: application/json

{
  "message": "길을 잃었어요",
  "location": {
    "latitude": 37.5665,
    "longitude": 126.9780
  },
  "destination_address": "서울시 강남구",
  "mode": "대중교통",
  "user_context": "지하철을 놓쳤어요"
}
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)