### PR TITLE
fix: Remove /api/emotions and /api/v1/chat from permitAll

### DIFF
--- a/src/main/java/com/untitled/cherrymap/common/config/SecurityConfig.java
+++ b/src/main/java/com/untitled/cherrymap/common/config/SecurityConfig.java
@@ -65,7 +65,7 @@ public class SecurityConfig {
                 // 경로별 인가 설정
                 .authorizeHttpRequests(auth -> auth
                         // 누구나 접근 가능한 공개 경로
-                        .requestMatchers("/", "/index.html", "/api/login", "/api/join","/api/check-nickname", "/api/reissue","/api/logout", "/api/emotions", "/api/v1/chat").permitAll()
+                        .requestMatchers("/", "/index.html", "/api/login", "/api/join","/api/check-nickname", "/api/reissue","/api/logout").permitAll()
                         // Swagger UI 관련 경로 허용
                         .requestMatchers("/cherrymap-ui.html", "/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**").permitAll()
                         // 정적 리소스 허용


### PR DESCRIPTION
## #️⃣연관된 이슈

> #91 #100 

## 📝작업 내용
- SecurityConfig에서 잘못 설정된 보안 권한을 수정.
- `api/emotions`와 `/api/v1/chat ` 엔드포인트가 .permitAll()로 설정되어 있어서 토큰 없이도 접근 가능했지만,
실제로는 컨트롤러에서는 사용자 인증을 요구하는 모순된 상황을 해결.