### PR TITLE
LLM 챗봇 API 인증 강화 및 회원가입 유효성 검사 개선

### DIFF
--- a/src/main/java/com/untitled/cherrymap/common/config/SecurityConfig.java
+++ b/src/main/java/com/untitled/cherrymap/common/config/SecurityConfig.java
@@ -65,7 +65,7 @@ public class SecurityConfig {
                 // 경로별 인가 설정
                 .authorizeHttpRequests(auth -> auth
                         // 누구나 접근 가능한 공개 경로
-                        .requestMatchers("/", "/index.html", "/api/login", "/api/join","/api/check-nickname", "/api/reissue","/api/logout").permitAll()
+                        .requestMatchers("/", "/index.html", "/api/login", "/api/join","/api/check-nickname", "/api/reissue","/api/logout", "/api/emotions").permitAll()
                         // Swagger UI 관련 경로 허용
                         .requestMatchers("/cherrymap-ui.html", "/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**").permitAll()
                         // 정적 리소스 허용

--- a/src/main/java/com/untitled/cherrymap/domain/llm/api/LlmController.java
+++ b/src/main/java/com/untitled/cherrymap/domain/llm/api/LlmController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
+@Slf4j
 @Tag(name = "LLM Chat", description = "LLM 챗봇 API")
 public class LlmController {
 
@@ -42,7 +44,10 @@ public class LlmController {
     public ResponseEntity<LlmChatResponse> chat(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetailsDTO user,
             @RequestBody LlmChatRequest request
-    ) {
-        return ResponseEntity.ok(llmService.processChatRequest(request));
+    ) {    
+        Long memberId = user.getMember().getId();
+        log.info("사용자 {} (ID: {}) 챗봇 요청: {}", user.getNickname(), memberId, request.message().substring(0, Math.min(50, request.message().length())));
+        
+        return ResponseEntity.ok(llmService.processChatRequest(request, memberId));
     }
 } 

--- a/src/main/java/com/untitled/cherrymap/security/JoinController.java
+++ b/src/main/java/com/untitled/cherrymap/security/JoinController.java
@@ -4,6 +4,7 @@ import com.untitled.cherrymap.common.dto.SuccessResponse;
 import com.untitled.cherrymap.domain.member.exception.DuplicateNicknameException;
 import com.untitled.cherrymap.security.dto.JoinDTO;
 import com.untitled.cherrymap.domain.member.dao.MemberRepository;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -25,7 +26,7 @@ public class JoinController {
     private final MemberRepository memberRepository;
 
     @PostMapping("/join")
-    public ResponseEntity<SuccessResponse> joinProcess(@RequestBody JoinDTO joinDTO) {
+    public ResponseEntity<SuccessResponse> joinProcess(@RequestBody @Valid JoinDTO joinDTO) {
         joinService.joinProcess(joinDTO);
         return ResponseEntity.ok(
                 SuccessResponse.success(201, Map.of("nickname", joinDTO.getNickname(), "message", "회원가입 완료"))

--- a/src/main/java/com/untitled/cherrymap/security/dto/JoinDTO.java
+++ b/src/main/java/com/untitled/cherrymap/security/dto/JoinDTO.java
@@ -1,12 +1,31 @@
 package com.untitled.cherrymap.security.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 @Getter
+@Schema(description = "회원가입 요청 DTO")
 public class JoinDTO {
+    
+    @NotNull(message = "닉네임은 필수입니다.")
+    @Schema(description = "닉네임", example = "cherry_user")
     private String nickname;
+    
+    @NotNull(message = "아이디는 필수입니다.")
+    @Schema(description = "아이디", example = "user123")
     private String username;
+    
+    @NotNull(message = "비밀번호는 필수입니다.")
+    @Schema(description = "비밀번호", example = "password123")
     private String password;
+    
+    @NotNull(message = "전화번호는 필수입니다.")
+    @Pattern(regexp = "^(\\d{3}-\\d{4}-\\d{4}|\\d{3}-\\d{3}-\\d{4})$", 
+             message = "전화번호는 xxx-xxxx-xxxx(휴대폰) 또는 xxx-xxx-xxxx(유선전화) 형식이어야 합니다.")
+    @Schema(description = "전화번호", example = "010-1234-5678", 
+            allowableValues = {"휴대폰: xxx-xxxx-xxxx", "유선전화: xxx-xxx-xxxx"})
     private String phoneNumber;
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #100 (LLM 챗봇 API 중계 기능 구현)

## 작업 내용
> LLM 챗봇 API의 보안을 강화하고 회원가입 시 데이터 검증을 개선
### 주요 변경사항
1. LLM 챗봇 API 인증 강화
- `LlmService`에 `MemberRepository` 주입하여 `memberId` 검증 로직 추가
- `EmotionService`와 동일한 패턴으로 일관성 있는 코드 구조 구현
사용자별 상세한 로깅 메시지 추가로 디버깅 및 모니터링 개선
2. 보안 설정 개선
- `/api/emotions` 엔드포인트를 공개 경로에 추가하여 인증 없이 접근 가능
3. 회원가입 유효성 검사 강화
- `JoinDTO`에 전화번호 형식 검증 추가 (휴대폰: xxx-xxxx-xxxx, 유선전화: xxx-xxx-xxxx)
- 비상 연락처 추가와 동일한 검증 패턴 적용으로 일관성 확보
- `JoinController`에 `@Valid` 어노테이션 추가로 실제 검증 실행
- Swagger API 문서화 개선 (예시 값, 설명 추가)